### PR TITLE
chore(release): 0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2191,7 +2191,7 @@ checksum = "3bccab0e7fd7cc19f820a1c8c91720af652d0c88dc9664dd72aef2614f04af3b"
 
 [[package]]
 name = "posh-tabcomplete"
-version = "0.1.6"
+version = "0.2.0"
 dependencies = [
  "clap",
  "diff",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "posh-tabcomplete"
-version = "0.1.6"
+version = "0.2.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Blazing fast tab completion for powershell."


### PR DESCRIPTION
## What's Changed
* Update dependencies by @domsleee in https://github.com/domsleee/posh-tabcomplete/pull/16
* Add `git diff` completion and update deps (nushell 0.87.1) by @domsleee in https://github.com/domsleee/posh-tabcomplete/pull/17


**Full Changelog**: https://github.com/domsleee/posh-tabcomplete/compare/0.1.6...0.2.0