### PR TITLE
fix: Completions of paths with spaces and single quotes

### DIFF
--- a/resource/completions.nu
+++ b/resource/completions.nu
@@ -1,5 +1,5 @@
 def "nu-complete git branches" [] {
-  ^git branch | lines | each { |line| $line | str replace '\* ' "" | str trim }
+  ^git branch | lines | each { |line| $line | str replace '* ' "" | str trim }
 }
 
 def "nu-complete git switchable branches" [] {

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,11 +55,11 @@ fn complete(root_args: &RootArgs, complete_args: &CompleteArgs) -> Result<(), st
 }
 
 fn maybe_process_path(arg: &str) -> String {
-    if arg.len() > 1 && arg.starts_with("`") && arg.ends_with("`") {
+    if arg.len() > 1 && arg.starts_with('`') && arg.ends_with('`') {
         // replace the start and end backticks with single quotes
         // also replace all single quotes with double single quote
-        let replaced_single_quotes = &arg[1..arg.len() - 1].replace("'", "''");
-        return format!("'{replaced_single_quotes}'", );
+        let replaced_single_quotes = &arg[1..arg.len() - 1].replace('\'', "''");
+        return format!("'{replaced_single_quotes}'",);
     }
 
     arg.to_string()

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,11 +47,22 @@ fn complete(root_args: &RootArgs, complete_args: &CompleteArgs) -> Result<(), st
     let suggestions = completer.complete(arg_str, arg_str.len());
     let suggestion_strings: Vec<String> = suggestions
         .iter()
-        .map(|x| x.value.clone().split(' ').last().unwrap().to_string())
+        .map(|x| maybe_process_path(&x.value.clone().to_string()))
         .collect();
 
     println!("{}", suggestion_strings.join("\n"));
     Ok(())
+}
+
+fn maybe_process_path(arg: &str) -> String {
+    if arg.len() > 1 && arg.starts_with("`") && arg.ends_with("`") {
+        // replace the start and end backticks with single quotes
+        // also replace all single quotes with double single quote
+        let replaced_single_quotes = &arg[1..arg.len() - 1].replace("'", "''");
+        return format!("'{replaced_single_quotes}'", );
+    }
+
+    arg.to_string()
 }
 
 fn get_string_from_files(root_args: &RootArgs) -> String {

--- a/tests/test_complete_git.rs
+++ b/tests/test_complete_git.rs
@@ -79,20 +79,42 @@ fn test_complete_nongit_command(shell: &str) {
 
 #[apply(shell_to_use)]
 fn test_file_completion_edgecases(shell: &str) -> std::io::Result<()> {
-    assert_file_completion(shell, "myfile with spaces.txt", "'myfile with spaces.txt'", "my")?;
-    assert_file_completion(shell, "myfilewith'quote.txt", "'myfilewith''quote.txt'", "my")?;
-    assert_file_completion(shell, "myfile with ' quote spaces.txt", "'myfile with '' quote spaces.txt'", "my")?;
-    
+    assert_file_completion(
+        shell,
+        "myfile with spaces.txt",
+        "'myfile with spaces.txt'",
+        "my",
+    )?;
+    assert_file_completion(
+        shell,
+        "myfilewith'quote.txt",
+        "'myfilewith''quote.txt'",
+        "my",
+    )?;
+    assert_file_completion(
+        shell,
+        "myfile with ' quote spaces.txt",
+        "'myfile with '' quote spaces.txt'",
+        "my",
+    )?;
+
     // seems broken in nushell?
     // assert_file_completion(shell, "myfilewith`backtick.txt", "'myfilewith`backtick.txt'", "my")?;
 
     Ok(())
 }
 
-fn assert_file_completion(shell: &str, filename: &str, expected: &str, completion: &str) -> std::io::Result<()> {
+fn assert_file_completion(
+    shell: &str,
+    filename: &str,
+    expected: &str,
+    completion: &str,
+) -> std::io::Result<()> {
     let testenv = TestEnv::new(shell);
     std::fs::write(testenv.temp_dir.path().join(filename), "AAA")?;
-    let res = testenv.run_with_profile(&format!("Invoke-TabComplete 'git add {completion}'")).unwrap();
+    let res = testenv
+        .run_with_profile(&format!("Invoke-TabComplete 'git add {completion}'"))
+        .unwrap();
     let lines: Vec<String> = res.stdout.lines().map(|x| x.unwrap()).collect_vec();
     assert_that!(lines).is_equal_to(vec![expected.to_string()]);
     Ok(())

--- a/tests/test_complete_git.rs
+++ b/tests/test_complete_git.rs
@@ -73,6 +73,27 @@ fn test_complete_nongit_command(shell: &str) {
     let res = testenv
         .run_with_profile("Invoke-TabComplete 'burrito -'")
         .unwrap();
-    let lines = res.stdout.lines().map(|x| x.unwrap()).collect_vec();
+    let lines: Vec<String> = res.stdout.lines().map(|x| x.unwrap()).collect_vec();
     assert_that!(lines).contains("--hello-there".to_string());
+}
+
+#[apply(shell_to_use)]
+fn test_file_completion_edgecases(shell: &str) -> std::io::Result<()> {
+    assert_file_completion(shell, "myfile with spaces.txt", "'myfile with spaces.txt'", "my")?;
+    assert_file_completion(shell, "myfilewith'quote.txt", "'myfilewith''quote.txt'", "my")?;
+    assert_file_completion(shell, "myfile with ' quote spaces.txt", "'myfile with '' quote spaces.txt'", "my")?;
+    
+    // seems broken in nushell?
+    // assert_file_completion(shell, "myfilewith`backtick.txt", "'myfilewith`backtick.txt'", "my")?;
+
+    Ok(())
+}
+
+fn assert_file_completion(shell: &str, filename: &str, expected: &str, completion: &str) -> std::io::Result<()> {
+    let testenv = TestEnv::new(shell);
+    std::fs::write(testenv.temp_dir.path().join(filename), "AAA")?;
+    let res = testenv.run_with_profile(&format!("Invoke-TabComplete 'git add {completion}'")).unwrap();
+    let lines: Vec<String> = res.stdout.lines().map(|x| x.unwrap()).collect_vec();
+    assert_that!(lines).is_equal_to(vec![expected.to_string()]);
+    Ok(())
 }


### PR DESCRIPTION
fixes: #19

Any completion returned by nushell starting and ending with a backtick (`) is considered a path.

This changes the backticks to single quotes, and replaces all single quotes in the completion with double single quotes - this seems to be the standard way for escaping single quotes in a single-quoted string in powershell.

There may be some other cases to consider, but this is a good start~