### PR TITLE
fix: completions should only include last argument

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -62,7 +62,7 @@ fn maybe_process_path(arg: &str) -> String {
         return format!("'{replaced_single_quotes}'",);
     }
 
-    arg.to_string()
+    arg.split(' ').last().unwrap().to_string()
 }
 
 fn get_string_from_files(root_args: &RootArgs) -> String {

--- a/tests/test_complete_git.rs
+++ b/tests/test_complete_git.rs
@@ -12,6 +12,13 @@ mod testenv;
 pub use testenv::*;
 
 #[apply(shell_to_use)]
+fn test_primary_command_is_not_included(shell: &str) {
+    let lines = util::run_command(shell, "Invoke-TabComplete 'git check'");
+    assert_that!(lines).does_not_contain("git checkout".to_string());
+    assert_that!(lines).contains("checkout".to_string());
+}
+
+#[apply(shell_to_use)]
 fn test_checkout_branches(shell: &str) {
     let lines = util::run_command(shell, "Invoke-TabComplete 'git checkout '");
     assert_that!(lines).contains("testbranch".to_string());


### PR DESCRIPTION
Fixes #24 

Not sure if this is the appropriate fix but it looked like splitting the arg got lost in the recent changes to how files with spaces are handled. The test case fails on current main and works with the change though!

Let me know if I should include any changelog, version bumps or other chores in this as well!