### PR TITLE
chore(release): 0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2426,7 +2426,7 @@ checksum = "7170ef9988bc169ba16dd36a7fa041e5c4cbeb6a35b76d4c03daded371eae7c0"
 
 [[package]]
 name = "posh-tabcomplete"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "clap",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "posh-tabcomplete"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Blazing fast tab completion for powershell."


### PR DESCRIPTION
## What's Changed
* Smaller binary with `panic = 'abort'`, update benchmark scripts by @domsleee in https://github.com/domsleee/posh-tabcomplete/pull/22
* Update to nushell 0.97.1, update deps by @domsleee in https://github.com/domsleee/posh-tabcomplete/pull/23
* fix: completions should only include last argument by @mvarendorff2 in https://github.com/domsleee/posh-tabcomplete/pull/25

## New Contributors
* @mvarendorff2 made their first contribution in https://github.com/domsleee/posh-tabcomplete/pull/25

**Full Changelog**: https://github.com/domsleee/posh-tabcomplete/compare/0.2.1...0.3.0