### PR TITLE
fix: Completions with special characters (e.g. '"&$`) are quoted

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,7 +85,7 @@ jobs:
           ./target/${{ matrix.target }}/release/posh-tabcomplete.exe
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.target }}
           path: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -473,9 +473,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.16"
+version = "4.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed6719fffa43d0d87e5fd8caeab59be1554fb028cd30edc88fc4369b17971019"
+checksum = "3e5a21b8495e732f1b3c364c9949b201ca7bae518c502c80256c96ad79eaf6ac"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -483,9 +483,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.15"
+version = "4.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "216aec2b177652e3846684cbfe25c9964d18ec45234f0f5da5157b207ed1aab6"
+checksum = "8cf2dd12af7a047ad9d6da2b6b249759a22a7abc0f474c1dae1777afa4b21a73"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1313,6 +1313,15 @@ name = "itertools"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -2430,7 +2439,7 @@ version = "0.3.0"
 dependencies = [
  "clap",
  "env_logger",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "log",
  "nu-cli",
  "nu-cmd-lang",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,8 @@ readme = "README.md"
 rust-version = "1.78.0"
 
 [dependencies]
-clap = { version = "4.5.16", features = ["derive"] }
-itertools = "0.12"
+clap = { version = "4.5.17", features = ["derive"] }
+itertools = "0.13"
 log = "0.4"
 nu-cli = "0.97.1"
 nu-command = "0.97.1"

--- a/src/completer.rs
+++ b/src/completer.rs
@@ -31,7 +31,8 @@ fn get_suggestion_string(suggestion: &Suggestion) -> String {
             || arg.contains('\"')
             || arg.contains('\'')
             || arg.contains('`')
-            || arg.contains('&'))
+            || arg.contains('&')
+            || arg.contains('$'))
     {
         let replaced_arg = arg.replace('\'', "''");
         return format!("'{replaced_arg}'");

--- a/src/completer.rs
+++ b/src/completer.rs
@@ -1,0 +1,58 @@
+use crate::nu_util;
+use reedline::{Completer, Suggestion};
+use std::path::Path;
+
+pub fn get_suggestions(nu_file_data: &[u8], pwd: &Path, arg_str: &str) -> Vec<String> {
+    let mut completer = nu_util::extern_completer(pwd, nu_file_data);
+    let suggestions = completer.complete(arg_str, arg_str.len());
+    let suggestion_strings: Vec<String> = suggestions.iter().map(get_suggestion_string).collect();
+    suggestion_strings
+}
+
+fn get_suggestion_string(suggestion: &Suggestion) -> String {
+    let arg = suggestion.value.clone().to_string();
+    if arg.len() > 1 && arg.starts_with('`') && arg.ends_with('`') {
+        // replace the start and end backticks with single quotes
+        // also replace all single quotes with double single quote
+        // e.g. completion of `git add ` with a file with a space in it
+        let replaced_single_quotes = &arg[1..arg.len() - 1].replace('\'', "''");
+        return format!("'{replaced_single_quotes}'",);
+    }
+
+    // for example, `git ch` should be `checkout`, not `git checkout`
+    if suggestion.span.start == 0 {
+        return arg.split(' ').last().unwrap().to_string();
+    }
+
+    // if the arg contains a special character, wrap it in single quotes
+    if !arg.is_empty()
+        && !arg.starts_with('\'')
+        && (arg.contains(' ')
+            || arg.contains('\"')
+            || arg.contains('\'')
+            || arg.contains('`')
+            || arg.contains('&'))
+    {
+        let replaced_arg = arg.replace('\'', "''");
+        return format!("'{replaced_arg}'");
+    }
+
+    arg.to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::DEFAULT_CONFIG_DATA;
+
+    use super::*;
+
+    #[test]
+    fn test_get_suggestions() {
+        let nu_file_data: &[u8] = DEFAULT_CONFIG_DATA;
+        let pwd = std::env::current_dir().unwrap();
+        let arg_str = "git checkou";
+        let expected = vec!["checkout".to_string()];
+        let suggestions = get_suggestions(nu_file_data, &pwd, arg_str);
+        assert_eq!(suggestions, expected);
+    }
+}

--- a/tests/test_complete_npm.rs
+++ b/tests/test_complete_npm.rs
@@ -11,6 +11,90 @@ pub use testenv::*;
 #[apply(shell_to_use)]
 fn test_npm_run(shell: &str) {
     let lines = util::run_command(shell, "Invoke-TabComplete 'npm run '");
-    assert_that!(lines).contains("script1".to_string());
-    assert_that!(lines).contains("script2".to_string());
+    assert_eq!(lines, vec!["script1", "script2"]);
+}
+
+#[apply(shell_to_use)]
+fn test_npm_run_space(shell: &str) -> Result<(), std::io::Error> {
+    let test_env = TestEnv::new(shell).create_package_json(
+        r#"
+            {
+                "scripts": {
+                    "with space": "echo hello world",
+                }
+            }
+        "#,
+    )?;
+
+    let lines = util::run_with_test_env(&test_env, "Invoke-TabComplete 'npm run with'");
+    assert_eq!(&lines, &["'with space'".to_string()]);
+    Ok(())
+}
+
+#[apply(shell_to_use)]
+fn test_npm_run_single_quotes(shell: &str) -> Result<(), std::io::Error> {
+    let test_env = TestEnv::new(shell).create_package_json(
+        r#"
+            {
+                "scripts": {
+                    "withsingle'quote": "echo hello world",
+                }
+            }
+        "#,
+    )?;
+
+    let lines = util::run_with_test_env(&test_env, "Invoke-TabComplete 'npm run with'");
+    assert_that!(&lines).equals_iterator(&["'withsingle''quote'".to_string()].iter());
+    Ok(())
+}
+
+#[apply(shell_to_use)]
+fn test_npm_run_double_quotes(shell: &str) -> Result<(), std::io::Error> {
+    let test_env = TestEnv::new(shell).create_package_json(
+        r#"
+            {
+                "scripts": {
+                    "withdouble\"quote": "echo hello world",
+                }
+            }
+        "#,
+    )?;
+
+    let lines = util::run_with_test_env(&test_env, "Invoke-TabComplete 'npm run with'");
+    assert_that!(&lines).equals_iterator(&[r#"'withdouble"quote'"#.to_string()].iter());
+    Ok(())
+}
+
+#[apply(shell_to_use)]
+fn test_npm_run_backticks(shell: &str) -> Result<(), std::io::Error> {
+    let test_env = TestEnv::new(shell).create_package_json(
+        r#"
+            {
+                "scripts": {
+                    "with`backtick": "echo hello world",
+                }
+            }
+        "#,
+    )?;
+
+    let lines = util::run_with_test_env(&test_env, "Invoke-TabComplete 'npm run with'");
+    assert_that!(&lines).equals_iterator(&[r#"'with`backtick'"#.to_string()].iter());
+    Ok(())
+}
+
+#[apply(shell_to_use)]
+fn test_npm_run_ampersand(shell: &str) -> Result<(), std::io::Error> {
+    let test_env = TestEnv::new(shell).create_package_json(
+        r#"
+            {
+                "scripts": {
+                    "with&ampersand": "echo hello world",
+                }
+            }
+        "#,
+    )?;
+
+    let lines = util::run_with_test_env(&test_env, "Invoke-TabComplete 'npm run with'");
+    assert_that!(&lines).equals_iterator(&[r#"'with&ampersand'"#.to_string()].iter());
+    Ok(())
 }

--- a/tests/test_complete_npm.rs
+++ b/tests/test_complete_npm.rs
@@ -98,3 +98,20 @@ fn test_npm_run_ampersand(shell: &str) -> Result<(), std::io::Error> {
     assert_that!(&lines).equals_iterator(&[r#"'with&ampersand'"#.to_string()].iter());
     Ok(())
 }
+
+#[apply(shell_to_use)]
+fn test_npm_run_dollar(shell: &str) -> Result<(), std::io::Error> {
+    let test_env = TestEnv::new(shell).create_package_json(
+        r#"
+            {
+                "scripts": {
+                    "with$dollar": "echo hello world",
+                }
+            }
+        "#,
+    )?;
+
+    let lines = util::run_with_test_env(&test_env, "Invoke-TabComplete 'npm run with'");
+    assert_that!(&lines).equals_iterator(&[r#"'with$dollar'"#.to_string()].iter());
+    Ok(())
+}

--- a/tests/testenv/util.rs
+++ b/tests/testenv/util.rs
@@ -4,6 +4,10 @@ use crate::TestEnv;
 
 pub fn run_command(shell: &str, command: &str) -> Vec<String> {
     let testenv = TestEnv::new(shell);
+    run_with_test_env(&testenv, command)
+}
+
+pub fn run_with_test_env(testenv: &TestEnv, command: &str) -> Vec<String> {
     let res = testenv.run_with_profile(command).unwrap();
     res.stdout.lines().map(|x| x.unwrap()).collect()
 }


### PR DESCRIPTION
Mentioned https://github.com/domsleee/posh-tabcomplete/issues/24#issuecomment-2321561807

New behaviour is to add single quotes around completions with special characters.

An example `package.json` file:
```json
{
    "scripts": {
        "with space": "echo hello world",
        "withsingle'quote": "echo hello world",
        "withdouble\"quote": "echo hello world",
        "with`backtick": "echo hello world",
        "with&ampersand": "echo hello world",
        "with$dollar": "echo hello world"
    }
}
```

| Old                | New                   |
| ------------------ | --------------------- |
| `with space`       | `'with space'`        |
| `withsingle'quote` | `'withsingle''quote'` |
| `withsingle"quote` | `'withdouble"quote'`  |
| ``with`backtick"`` | ``'with`backtick'``  |
| `with&ampersand` | `'with&ampersand'` |
| `with$dollar` | `'with$dollar'` |