### PR TITLE
Make binary smaller by rebuilding std with -Oz and panic_abort

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
           rustup component add rust-src --target ${{ matrix.target }}
 
       - name: Build binary
-        run: cargo build --release -Z build-std=core,std,alloc,proc_macro,panic_abort -Z build-std-features=panic_immediate_abort,optimize_for_size --locked --target=${{ matrix.target }} --color=always
+        run: cargo build --release -Z build-std=core,std,alloc,proc_macro,panic_abort -Z build-std-features=panic_immediate_abort --locked --target=${{ matrix.target }} --color=always
 
       - name: Install cargo-deb
         if: ${{ matrix.deb == true }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,7 @@ jobs:
           cargo build 
             --release 
             -Z build-std=core,std,alloc,proc_macro,panic_abort 
-            -Z build-std-features=panic_immediate_abort,optimize_for_size" 
+            -Z build-std-features=panic_immediate_abort,optimize_for_size 
             --locked --target=${{ matrix.target }} --color=always
 
       - name: Install cargo-deb

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,9 +62,10 @@ jobs:
       - name: Build binary
         run: |
           cargo build \
-          -Z build-std=core,std,alloc,proc_macro,panic_abort \
-          -Z build-std-features=panic_immediate_abort \
-          --release --locked --target=${{ matrix.target }} --color=always
+            --release \
+            -Z build-std=core,std,alloc,proc_macro,panic_abort \
+            -Z build-std-features=panic_immediate_abort \
+            --locked --target=${{ matrix.target }} --color=always
 
       - name: Install cargo-deb
         if: ${{ matrix.deb == true }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,9 @@ jobs:
           toolchain: nightly-2024-05-16
 
       - name: Install cargo-src
-        run: rustup component add rust-src --toolchain nightly-2024-05-16-${{ matrix.target }}
+        run: |
+          rustup target add ${{ matrix.target }}
+          rustup component add rust-src --target ${{ matrix.target }}
 
       - name: Build binary
         run: cargo build -Z build-std=core,std,alloc,proc_macro,panic_abort -Z build-std-features=panic_immediate_abort --release --locked --target=${{ matrix.target }} --color=always

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,11 @@ jobs:
           rustup component add rust-src --target ${{ matrix.target }}
 
       - name: Build binary
-        run: cargo build -Z build-std=core,std,alloc,proc_macro,panic_abort -Z build-std-features=panic_immediate_abort --release --locked --target=${{ matrix.target }} --color=always
+        run: |
+          cargo build \
+          -Z build-std=core,std,alloc,proc_macro,panic_abort \
+          -Z build-std-features=panic_immediate_abort \
+          --release --locked --target=${{ matrix.target }} --color=always
 
       - name: Install cargo-deb
         if: ${{ matrix.deb == true }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,6 +54,9 @@ jobs:
           target: ${{ matrix.target }}
           toolchain: nightly-2024-05-16
 
+      - name: Install cargo-src
+        run: rustup component add rust-src --toolchain nightly-2024-05-16-${{ matrix.target }}
+
       - name: Build binary
         run: cargo build -Z build-std=core,std,alloc,proc_macro,panic_abort -Z build-std-features=panic_immediate_abort --release --locked --target=${{ matrix.target }} --color=always
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,10 +61,10 @@ jobs:
 
       - name: Build binary
         run: |
-          cargo build \
-            --release \
-            -Z build-std=core,std,alloc,proc_macro,panic_abort \
-            -Z build-std-features=panic_immediate_abort \
+          cargo build 
+            --release 
+            -Z build-std=core,std,alloc,proc_macro,panic_abort 
+            -Z build-std-features=panic_immediate_abort,optimize_for_size" 
             --locked --target=${{ matrix.target }} --color=always
 
       - name: Install cargo-deb

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,12 +60,7 @@ jobs:
           rustup component add rust-src --target ${{ matrix.target }}
 
       - name: Build binary
-        run: |
-          cargo build 
-            --release 
-            -Z build-std=core,std,alloc,proc_macro,panic_abort 
-            -Z build-std-features=panic_immediate_abort,optimize_for_size 
-            --locked --target=${{ matrix.target }} --color=always
+        run: cargo build --release -Z build-std=core,std,alloc,proc_macro,panic_abort -Z build-std-features=panic_immediate_abort,optimize_for_size --locked --target=${{ matrix.target }} --color=always
 
       - name: Install cargo-deb
         if: ${{ matrix.deb == true }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,6 +52,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1.9.0
         with:
           target: ${{ matrix.target }}
+          toolchain: nightly-2024-05-16
 
       - name: Build binary
         run: cargo build -Z build-std=core,std,alloc,proc_macro,panic_abort -Z build-std-features=panic_immediate_abort --release --locked --target=${{ matrix.target }} --color=always

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,6 +60,7 @@ jobs:
           rustup component add rust-src --target ${{ matrix.target }}
 
       - name: Build binary
+        # use optimize_for_size in the future (https://github.com/rust-lang/rust/issues/125612)
         run: cargo build --release -Z build-std=core,std,alloc,proc_macro,panic_abort -Z build-std-features=panic_immediate_abort --locked --target=${{ matrix.target }} --color=always
 
       - name: Install cargo-deb

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
           target: ${{ matrix.target }}
 
       - name: Build binary
-        run: cargo build --release --locked --target=${{ matrix.target }} --color=always
+        run: cargo build -Z build-std=core,std,alloc,proc_macro,panic_abort -Z build-std-features=panic_immediate_abort --release --locked --target=${{ matrix.target }} --color=always
 
       - name: Install cargo-deb
         if: ${{ matrix.deb == true }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -251,7 +251,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f58b559fd6448c6e2fd0adb5720cd98a2506594cafa4737ff98c396f3e82f667"
 dependencies = [
  "borsh-derive",
- "cfg_aliases",
+ "cfg_aliases 0.1.1",
 ]
 
 [[package]]
@@ -403,6 +403,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "chardetng"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -473,9 +479,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.17"
+version = "4.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e5a21b8495e732f1b3c364c9949b201ca7bae518c502c80256c96ad79eaf6ac"
+checksum = "b0956a43b323ac1afaffc053ed5c4b7c1f1800bacd1683c353aabbb752515dd3"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -483,9 +489,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.17"
+version = "4.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cf2dd12af7a047ad9d6da2b6b249759a22a7abc0f474c1dae1777afa4b21a73"
+checksum = "4d72166dd41634086d5803a47eb71ae740e61d84709c36f3c34110173db3961b"
 dependencies = [
  "anstream",
  "anstyle",
@@ -496,9 +502,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.13"
+version = "4.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "501d359d5f3dcaf6ecdeee48833ae73ec6e42723a1e52419c79abf9507eec0a0"
+checksum = "4ac6a0c7b1a9e9a5186361f67dfa1b88213572f427fb9ab038efb2bd8c582dab"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -558,15 +564,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-xid",
-]
-
-[[package]]
-name = "convert_case"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
-dependencies = [
- "unicode-segmentation",
 ]
 
 [[package]]
@@ -639,15 +636,15 @@ checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
 
 [[package]]
 name = "crossterm"
-version = "0.27.0"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f476fe445d41c9e991fd07515a6f463074b782242ccf4a5b7b1d1012e70824df"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
  "bitflags 2.4.2",
  "crossterm_winapi",
- "libc",
- "mio",
+ "mio 1.0.2",
  "parking_lot",
+ "rustix",
  "serde",
  "signal-hook",
  "signal-hook-mio",
@@ -695,6 +692,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
+
+[[package]]
 name = "deranged"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -702,12 +705,6 @@ checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
 dependencies = [
  "powerfmt",
 ]
-
-[[package]]
-name = "deunicode"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "339544cc9e2c4dc3fc7149fd630c5f22263a4fdf18a98afd0075784968b5cf00"
 
 [[package]]
 name = "dialoguer"
@@ -1136,6 +1133,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1381,9 +1384,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.153"
+version = "0.2.159"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+checksum = "561d97a539a36e26a9a5fad1ea11a3039a67714694aaa379433e580854bc3dc5"
 
 [[package]]
 name = "libloading"
@@ -1439,9 +1442,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
+checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
 name = "lock_api"
@@ -1455,9 +1458,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.21"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
+checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "lru"
@@ -1575,6 +1578,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "mio"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "multipart-rs"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1614,7 +1630,19 @@ checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
 dependencies = [
  "bitflags 2.4.2",
  "cfg-if",
- "cfg_aliases",
+ "cfg_aliases 0.1.1",
+ "libc",
+]
+
+[[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags 2.4.2",
+ "cfg-if",
+ "cfg_aliases 0.2.1",
  "libc",
 ]
 
@@ -1642,7 +1670,7 @@ dependencies = [
  "kqueue",
  "libc",
  "log",
- "mio",
+ "mio 0.8.11",
  "walkdir",
  "windows-sys 0.48.0",
 ]
@@ -1680,9 +1708,9 @@ dependencies = [
 
 [[package]]
 name = "nu-cli"
-version = "0.97.1"
+version = "0.98.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b646301afa88b6b8072e1ba585e99391049ccd26b46c0ff88af87f7c3e2bb2ab"
+checksum = "6598f608160e982681cb6fcee72ed1754874940652adc55423d4c68ba7532106"
 dependencies = [
  "chrono",
  "crossterm",
@@ -1711,9 +1739,9 @@ dependencies = [
 
 [[package]]
 name = "nu-cmd-base"
-version = "0.97.1"
+version = "0.98.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8688291aeff50a88d4733973a36ee6e74e7f25b86d377faa0061f8cfc6fb651"
+checksum = "7808b73a4024c8ba677ac646b30a19288e1b7c7b4274f43424a4ca6880eceff8"
 dependencies = [
  "indexmap",
  "miette",
@@ -1725,11 +1753,11 @@ dependencies = [
 
 [[package]]
 name = "nu-cmd-lang"
-version = "0.97.1"
+version = "0.98.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7a4c0018ea90425381bea318248a2bcead9f52bdd023743e2ddd5e89f431ff7"
+checksum = "7f0b87c36d5d922b43679ca21416fc136d246a95965a177b9ab98fe1efa77512"
 dependencies = [
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "nu-engine",
  "nu-parser",
  "nu-protocol",
@@ -1739,9 +1767,9 @@ dependencies = [
 
 [[package]]
 name = "nu-color-config"
-version = "0.97.1"
+version = "0.98.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea330c74ff8ea2d5a6ecaba618ca72b4ea7e2b08b689d8c22a426c7b4f910c1b"
+checksum = "e617a828111a2fbd486698dab3ffa3894a52d6c77805f86babd5527ecb002ec3"
 dependencies = [
  "nu-ansi-term",
  "nu-engine",
@@ -1752,9 +1780,9 @@ dependencies = [
 
 [[package]]
 name = "nu-command"
-version = "0.97.1"
+version = "0.98.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6635966ea24366181f1dfc2c3201a65152e7a4f7d696ac27f43b993b84457b08"
+checksum = "51090b0adac0c4f7aec76382537a209e89eb46158b1bee6ff3d3269e9e2df950"
 dependencies = [
  "alphanumeric-sort",
  "base64",
@@ -1769,7 +1797,7 @@ dependencies = [
  "chrono-tz",
  "crossterm",
  "csv",
- "deunicode",
+ "data-encoding",
  "dialoguer",
  "digest",
  "dtparse",
@@ -1780,7 +1808,7 @@ dependencies = [
  "human-date-parser",
  "indexmap",
  "indicatif",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "log",
  "lscolors",
  "md-5",
@@ -1788,7 +1816,7 @@ dependencies = [
  "mime_guess",
  "multipart-rs",
  "native-tls",
- "nix",
+ "nix 0.29.0",
  "notify-debouncer-full",
  "nu-ansi-term",
  "nu-cmd-base",
@@ -1820,7 +1848,6 @@ dependencies = [
  "regex",
  "rmp",
  "roxmltree",
- "same-file",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -1853,11 +1880,11 @@ dependencies = [
 
 [[package]]
 name = "nu-derive-value"
-version = "0.97.1"
+version = "0.98.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e4640556d6abc057dab7001bf5612f6b9b144ce739bfa0669d66fbf1ef7ad28"
+checksum = "1f2619f3ae9a21794cf4c49c2962c3e5274764d87a3e0d97587283796ae4b99a"
 dependencies = [
- "convert_case",
+ "heck",
  "proc-macro-error",
  "proc-macro2",
  "quote",
@@ -1866,9 +1893,9 @@ dependencies = [
 
 [[package]]
 name = "nu-engine"
-version = "0.97.1"
+version = "0.98.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa524164c6d87d9ce4dd1122525a539f92a77f4fbb6494452976cc2fa691742d"
+checksum = "1fab89403670cb3048f531ff8ac8d9cdfd9ac72862f9031194756d82729f9d8e"
 dependencies = [
  "log",
  "nu-glob",
@@ -1880,15 +1907,15 @@ dependencies = [
 
 [[package]]
 name = "nu-glob"
-version = "0.97.1"
+version = "0.98.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4097b0014c26a039018990a4fe8d8fd5658c00e94621b34751869649b0aa942"
+checksum = "8f2367837197545cca98329358342d08498a5cfc0911d446debb35e3bbc5b44a"
 
 [[package]]
 name = "nu-json"
-version = "0.97.1"
+version = "0.98.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bd1d64f5536b4ed618c857b2215330e2d6fcd869f62b7ca0b04350067ebc442"
+checksum = "7b9b4fc5ac76f928f8fcb04846c4c0662507cd09c173d7766cda53f4dc3c2b32"
 dependencies = [
  "linked-hash-map",
  "num-traits",
@@ -1898,13 +1925,13 @@ dependencies = [
 
 [[package]]
 name = "nu-parser"
-version = "0.97.1"
+version = "0.98.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7795158c373e239c2ff91c2d55fd3e8ae88c083e297f6480ec447c7e5007f125"
+checksum = "23fa0707d58bacb43227e3c1a48bb6c6cceb9c6e11ca70ebe5b307a4f66dd7cc"
 dependencies = [
  "bytesize",
  "chrono",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "log",
  "nu-engine",
  "nu-path",
@@ -1914,9 +1941,9 @@ dependencies = [
 
 [[package]]
 name = "nu-path"
-version = "0.97.1"
+version = "0.98.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96b4a7d68a196e55c8e2c8685293bc1c17e9c13aa7dac5bcbe04a2a841e92770"
+checksum = "08fdfbc5a5f6f86b21b3035dc8043b09543ecf4d505010df99b35231abeb9d44"
 dependencies = [
  "dirs",
  "omnipath",
@@ -1925,32 +1952,33 @@ dependencies = [
 
 [[package]]
 name = "nu-pretty-hex"
-version = "0.97.1"
+version = "0.98.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4019cc67a345d7259c86cf2d3cd2134b1594879003af22eb93b210c7ed380a9d"
+checksum = "d1944f13d01144273365c3435cf304f0730f567d485cce709a5b4a65279af1c2"
 dependencies = [
  "nu-ansi-term",
 ]
 
 [[package]]
 name = "nu-protocol"
-version = "0.97.1"
+version = "0.98.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38ae5262aabe662ac1cc02a6e8d3fdb48fa8bb25c77be72d2e8a625a7c3e4812"
+checksum = "22d2b192c6f44b22bf6fadebe8cb4c0450c5f3a1ef0760b10a8a34d86a408d37"
 dependencies = [
  "brotli",
  "byte-unit",
+ "bytes",
  "chrono",
  "chrono-humanize",
- "convert_case",
  "dirs",
  "dirs-sys",
  "fancy-regex",
+ "heck",
  "indexmap",
  "log",
  "lru",
  "miette",
- "nix",
+ "nix 0.29.0",
  "nu-derive-value",
  "nu-path",
  "nu-system",
@@ -1966,17 +1994,17 @@ dependencies = [
 
 [[package]]
 name = "nu-system"
-version = "0.97.1"
+version = "0.98.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ed001bb4cb39b4235871cb00650b79497084fc46beaf019d226239119d3ef5"
+checksum = "08076dc19b3b6b51721e70296f6ee50af46badad86fdbb3149dd39660140115c"
 dependencies = [
  "chrono",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "libc",
  "libproc",
  "log",
  "mach2",
- "nix",
+ "nix 0.29.0",
  "ntapi",
  "once_cell",
  "procfs",
@@ -1986,9 +2014,9 @@ dependencies = [
 
 [[package]]
 name = "nu-table"
-version = "0.97.1"
+version = "0.98.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deb79064bf173dae880114b7b3ebd162d8096642105bb4df0b711aced4063d30"
+checksum = "ef5adaef2f75c94d863e8336296cfe4e659b502518eb973c79e7d0a7c8897783"
 dependencies = [
  "fancy-regex",
  "nu-ansi-term",
@@ -2002,9 +2030,9 @@ dependencies = [
 
 [[package]]
 name = "nu-term-grid"
-version = "0.97.1"
+version = "0.98.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a67aa3a5ffe0699221007409fc2f83be7c7905d2269403215cd580f6af59881e"
+checksum = "d0eeb8c567aa3cd29bb1d9d1f78b349bfa9adc3a99a4e95a086594eb94947b2c"
 dependencies = [
  "nu-utils",
  "unicode-width",
@@ -2012,14 +2040,14 @@ dependencies = [
 
 [[package]]
 name = "nu-utils"
-version = "0.97.1"
+version = "0.98.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d91a233afaa875d01784c898f4464755cbefb5eaf8845032d651e39ac6354f"
+checksum = "e5d17bc14c181cb42fadbacfecbd2a4d68912dd24e49278e428e585b7b4ec7f3"
 dependencies = [
  "crossterm_winapi",
  "log",
  "lscolors",
- "nix",
+ "nix 0.29.0",
  "num-format",
  "serde",
  "strip-ansi-escapes",
@@ -2135,9 +2163,9 @@ checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "nuon"
-version = "0.97.1"
+version = "0.98.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75624629070af3809d9997f085328306d1f375df7abc5d663f3d6df915688324"
+checksum = "0b6159d22bc60e2c288d5a3584bb2cd20353c67995d7cd9dba2b01ae7739f5c2"
 dependencies = [
  "fancy-regex",
  "nu-engine",
@@ -2246,9 +2274,9 @@ checksum = "caff54706df99d2a78a5a4e3455ff45448d81ef1bb63c22cd14052ca0e993a3f"
 
 [[package]]
 name = "papergrid"
-version = "0.10.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2ccbe15f2b6db62f9a9871642746427e297b0ceb85f9a7f1ee5ff47d184d0c8"
+checksum = "c7419ad52a7de9b60d33e11085a0fe3df1fbd5926aa3f93d3dd53afbc9e86725"
 dependencies = [
  "ansi-str",
  "ansitok",
@@ -2691,9 +2719,9 @@ dependencies = [
 
 [[package]]
 name = "reedline"
-version = "0.34.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc271368d0d3f395745b40fababc0c9061f3fc2978189a8bc76f889e47255b01"
+checksum = "c5289de810296f8f2ff58d35544d92ae98d0a631453388bc3e608086be0fa596"
 dependencies = [
  "chrono",
  "crossterm",
@@ -2900,9 +2928,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.31"
+version = "0.38.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea3e1a662af26cd7a3ba09c0297a31af215563ecf42817c98df621387f4e949"
+checksum = "8acb788b847c24f28525660c4d7758620a7210875711f79e7f663cc152726811"
 dependencies = [
  "bitflags 2.4.2",
  "errno",
@@ -3061,9 +3089,9 @@ dependencies = [
 
 [[package]]
 name = "shadow-rs"
-version = "0.31.1"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02c282402d25101f9c893e9cd7e4cae535fe7db18b81291de973026c219ddf1e"
+checksum = "69fe0bac8a8752586a618a1c80d01d8ca5d40fce4f6077fbc851e48dcbdb90df"
 dependencies = [
  "const_format",
  "is_debug",
@@ -3094,12 +3122,12 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-mio"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29ad2e15f37ec9a6cc544097b78a1ec90001e9f71b81338ca39f430adaca99af"
+checksum = "34db1a06d485c9142248b7a054f034b349b212551f3dfd19c94d45a754a217cd"
 dependencies = [
  "libc",
- "mio",
+ "mio 1.0.2",
  "signal-hook",
 ]
 
@@ -3269,14 +3297,13 @@ dependencies = [
 
 [[package]]
 name = "tabled"
-version = "0.14.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfe9c3632da101aba5131ed63f9eed38665f8b3c68703a6bb18124835c1a5d22"
+checksum = "77c9303ee60b9bedf722012ea29ae3711ba13a67c9b9ae28993838b63057cb1b"
 dependencies = [
  "ansi-str",
  "ansitok",
  "papergrid",
- "unicode-width",
 ]
 
 [[package]]
@@ -3682,7 +3709,7 @@ dependencies = [
  "dunce",
  "glob",
  "libc",
- "nix",
+ "nix 0.28.0",
  "number_prefix",
  "once_cell",
  "os_display",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,16 +8,16 @@ repository = "https://github.com/domsleee/posh-tabcomplete"
 readme = "README.md"
 
 [dependencies]
-clap = { version = "4.5.17", features = ["derive"] }
+clap = { version = "4.5.18", features = ["derive"] }
 itertools = "0.13"
 log = "0.4"
-nu-cli = "0.97.1"
-nu-command = "0.97.1"
-nu-cmd-lang = "0.97.1"
-nu-engine = "0.97.1"
-nu-parser = "0.97.1"
-nu-protocol = "0.97.1"
-reedline = { version = "0.34.0", features = ["bashisms", "sqlite"] }
+nu-cli = "0.98.0"
+nu-command = "0.98.0"
+nu-cmd-lang = "0.98.0"
+nu-engine = "0.98.0"
+nu-parser = "0.98.0"
+nu-protocol = "0.98.0"
+reedline = { version = "0.35.0", features = ["bashisms", "sqlite"] }
 regex = "1.10.6"
 env_logger = "0.11.5"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,6 @@ license = "MIT OR Apache-2.0"
 description = "Blazing fast tab completion for powershell."
 repository = "https://github.com/domsleee/posh-tabcomplete"
 readme = "README.md"
-rust-version = "1.78.0"
 
 [dependencies]
 clap = { version = "4.5.17", features = ["derive"] }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.80.0-nightly"
+channel = "nightly-2024-05-16"
 profile = "default"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2024-05-16"
+channel = "1.80.0-nightly"
 profile = "default"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.78.0"
+channel = "nightly-2024-05-16"
 profile = "default"

--- a/src/nu_util.rs
+++ b/src/nu_util.rs
@@ -4,7 +4,7 @@ use nu_cli::NuCompleter;
 use nu_engine::eval_block;
 use nu_parser::parse;
 use nu_protocol::debugger::WithoutDebug;
-use nu_protocol::report_error;
+use nu_protocol::report_parse_error;
 use nu_protocol::{
     engine::{EngineState, Stack, StateWorkingSet},
     PipelineData, ShellError, Span, Value,
@@ -37,7 +37,7 @@ fn merge_input(
         let mut working_set = StateWorkingSet::new(engine_state);
         let block = parse(&mut working_set, None, input, false);
         if let Some(err) = working_set.parse_errors.first() {
-            report_error(&working_set, err);
+            report_parse_error(&working_set, err);
             std::process::exit(1);
         }
         (block, working_set.render())


### PR DESCRIPTION
* Using ideas from https://github.com/johnthagen/min-sized-rust
* Update to nushell 0.98.0

| Target                  | Old size | New size |
| ----------------------- | -------- | -------- |
| x86_64-apple-darwin     | 11,708   | 10,204   |
| aarch64-apple-darwin    | 9,919    | 8,480    |
| x86_64-pc-windows-msvc  | 12,187   | 10,737   |
| aarch64-pc-windows-msvc | 10,864   | 9,537    |