### PR TITLE
chore(release): 0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2463,7 +2463,7 @@ checksum = "7170ef9988bc169ba16dd36a7fa041e5c4cbeb6a35b76d4c03daded371eae7c0"
 
 [[package]]
 name = "posh-tabcomplete"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "clap",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "posh-tabcomplete"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Blazing fast tab completion for powershell."


### PR DESCRIPTION
## What's Changed
* fix: Completions with special characters (e.g. '"&$`) are quoted by @domsleee in https://github.com/domsleee/posh-tabcomplete/pull/27
* Update to nushell 0.98.0 & make binary smaller using `-Z` compiler flags @domsleee in https://github.com/domsleee/posh-tabcomplete/pull/28


**Full Changelog**: https://github.com/domsleee/posh-tabcomplete/compare/0.3.0...0.4.0