### PR TITLE
chore(release): 0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2594,7 +2594,7 @@ checksum = "280dc24453071f1b63954171985a0b0d30058d287960968b9b2aca264c8d4ee6"
 
 [[package]]
 name = "posh-tabcomplete"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "clap",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "posh-tabcomplete"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Blazing fast tab completion for powershell."


### PR DESCRIPTION
## What's Changed
* Update nushell to 0.101.0 by @domsleee in https://github.com/domsleee/posh-tabcomplete/pull/30
* Add binding for `bun run` by @domsleee in https://github.com/domsleee/posh-tabcomplete/pull/32
